### PR TITLE
🐛 bugfix [#20] : user, baseentity의 순환참조 버그 fix

### DIFF
--- a/src/main/java/com/sparta/spring_deep/_delivery/common/BaseEntity.java
+++ b/src/main/java/com/sparta/spring_deep/_delivery/common/BaseEntity.java
@@ -1,14 +1,14 @@
 package com.sparta.spring_deep._delivery.common;
 
-import com.sparta.spring_deep._delivery.domain.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,6 +17,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Data
+@Getter
+@Setter
 @RequiredArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
@@ -27,18 +29,16 @@ public class BaseEntity {
     private LocalDateTime createdAt;
 
     @CreatedBy
-    @ManyToOne
     @JoinColumn(name = "created_by")
-    private User createdBy;
+    private String createdBy;
 
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @LastModifiedBy
-    @ManyToOne
     @JoinColumn(name = "updated_by")
-    private User updatedBy;
+    private String updatedBy;
 
     @Column(name = "is_deleted")
     @ColumnDefault("FALSE")
@@ -47,26 +47,25 @@ public class BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @ManyToOne
     @JoinColumn(name = "deleted_by")
-    private User deletedBy;
+    private String deletedBy;
 
     // 생성을 위한 method 추가
-    public BaseEntity(User user) {
-        this.createdBy = user;
-        this.updatedBy = user;
+    public BaseEntity(String username) {
+        this.createdBy = username;
+        this.updatedBy = username;
         this.isDeleted = false;
     }
 
     // 소프트 delete를 위한 method 추가
-    public void delete(User user) {
+    public void delete(String username) {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
-        this.deletedBy = user;
+        this.deletedBy = username;
     }
 
     // 업데이트를 위한 method 추가
-    public void update(User user) {
-        this.updatedBy = user;
+    public void update(String username) {
+        this.updatedBy = username;
     }
 }


### PR DESCRIPTION
- BaseEntity의 ~By 필드 자료형을 User에서 String으로 변경해 username을 받도록 수정


## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [x] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  *     private User createdBy;
  *     private User updatedBy;
  *     private User deletedBy;

* **to-be**
  *     private String createdBy;
  *     private String updatedBy;
  *     private String deletedBy;


## 💡 추가 설명

* 없습니다.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
